### PR TITLE
feat: add websocket durable object and log analysis workflow

### DIFF
--- a/migrations/0002_diagnostics.sql
+++ b/migrations/0002_diagnostics.sql
@@ -1,0 +1,7 @@
+-- Store log analyses from Workers AI
+CREATE TABLE IF NOT EXISTS log_diagnostics (
+  id TEXT PRIMARY KEY,
+  log_key TEXT NOT NULL,
+  analysis TEXT,
+  created_at INTEGER
+);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript": "^5.5.4",
     "vitest": "^1.6.0",
     "wrangler": "^3.60.0",
-    "@types/node": "^20.14.9"
+    "@types/node": "^20.14.9",
+    "@cloudflare/workers-types": "^4.20240512.0"
   }
 }

--- a/src/durable-objects/homeAssistant.ts
+++ b/src/durable-objects/homeAssistant.ts
@@ -1,0 +1,29 @@
+import type { Env } from '../index';
+
+export class HomeAssistantWebSocket implements DurableObject {
+  private readonly state: DurableObjectState;
+  private env: Env;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request: Request) {
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('Expected websocket', { status: 400 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    server.accept();
+
+    // TODO: Bridge messages to Home Assistant websocket API
+    server.addEventListener('message', (ev) => {
+      // For now echo back
+      server.send(ev.data);
+    });
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,9 +3,26 @@ import app from './index';
 
 // Simple mocks for bindings
 const bindings = {
-  D1_DB: {} as any,
+  D1_DB: {
+    prepare() {
+      return {
+        bind() {
+          return { async run() {} };
+        }
+      };
+    }
+  } as any,
   KV: { async get() {}, async put() {}, async delete() {} } as any,
-  R2_BUCKET: {} as any
+  LOGS_BUCKET: { async put() {} } as any,
+  AI: { async run() { return { response: 'diag' }; } } as any,
+  WEBSOCKET_SERVER: {
+    idFromName() {
+      return {} as any;
+    },
+    get() {
+      return { fetch: () => new Response('not implemented', { status: 501 }) } as any;
+    }
+  } as any
 };
 const ctx = { waitUntil() {} } as any;
 
@@ -23,5 +40,18 @@ describe('Alexa REST API scaffold', () => {
     const data = await res.json();
     expect(data.ok).toBe(true);
     expect(data.data).toEqual({ added: 0, updated: 0, total: 0, reportUrl: null });
+  });
+
+  it('accepts log webhook', async () => {
+    const res = await app.request(
+      '/v1/webhooks/logs',
+      { method: 'POST', body: JSON.stringify({ level: 'ERROR', message: 'fail' }) },
+      bindings,
+      ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.data?.key).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
 import { Hono } from 'hono';
 import { v1 } from './routes/v1';
+import type { HomeAssistantWebSocket } from './durable-objects/homeAssistant';
 
 export interface Env {
   D1_DB: D1Database;
   KV: KVNamespace;
-  R2_BUCKET: R2Bucket;
+  LOGS_BUCKET: R2Bucket;
+  AI: Ai;
+  WEBSOCKET_SERVER: DurableObjectNamespace<HomeAssistantWebSocket>;
 }
 
 const app = new Hono<{ Bindings: Env }>();
@@ -66,5 +69,12 @@ app.get('/openapi.json', (c) => {
 
 // Mount /v1 group
 app.route('/v1', v1);
+
+app.get('/ws/:instanceId', (c) => {
+  const { instanceId } = c.req.param();
+  const id = c.env.WEBSOCKET_SERVER.idFromName(instanceId);
+  const stub = c.env.WEBSOCKET_SERVER.get(id);
+  return stub.fetch(c.req.raw);
+});
 
 export default app;

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { ok } from '../lib/response';
+import type { Env } from '../index';
 
-export const v1 = new Hono();
+export const v1 = new Hono<{ Bindings: Env }>();
 
 // NOTE: All are stubs. Real logic (LAN scan, Protect, D1, R2) comes next PR.
 
@@ -29,4 +30,27 @@ v1.get('/protect/cameras', async (c) => {
 v1.post('/protect/cameras/:id/snapshot', async (c) => {
   const { id } = c.req.param();
   return c.json(ok(`stub: camera snapshot for ${id}`, { imageUrl: null, camera: id }));
+});
+
+v1.post('/webhooks/logs', async (c) => {
+  const log = await c.req.json();
+  const key = `logs/${Date.now()}-${Math.random().toString(16).slice(2)}.json`;
+  await c.env.LOGS_BUCKET.put(key, JSON.stringify(log));
+
+  if (/error/i.test(JSON.stringify(log))) {
+    try {
+      const analysis = await c.env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
+        prompt: `Analyze Home Assistant log and provide diagnostics:\n${JSON.stringify(log)}`,
+        max_tokens: 256
+      });
+      const id = crypto.randomUUID();
+      await c.env.D1_DB.prepare(
+        'INSERT INTO log_diagnostics (id, log_key, analysis, created_at) VALUES (?, ?, ?, ?)' 
+      ).bind(id, key, analysis.response, Date.now()).run();
+    } catch (err) {
+      // swallow errors to avoid failing webhook
+    }
+  }
+
+  return c.json(ok('log stored', { key }));
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,3 +5,18 @@ declare interface KVNamespace {
   delete(key: string): Promise<any>;
 }
 declare interface R2Bucket {}
+
+declare interface Ai {
+  run(model: string, input: any): Promise<{ response: string }>;
+}
+
+interface DurableObjectId {}
+
+interface DurableObjectStub {
+  fetch(request: Request): Promise<Response>;
+}
+
+declare interface DurableObjectNamespace<T = any> {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): DurableObjectStub;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*"]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,9 @@ name = "hassio-proxy-worker"
 main = "dist/index.js"
 compatibility_date = "2025-08-01"
 
+[ai]
+binding = "AI"
+
 # Placeholders so we don’t touch this again next PR
 [[d1_databases]]
 binding = "D1_DB"
@@ -13,5 +16,9 @@ binding = "KV"
 id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 [[r2_buckets]]
-binding = "R2_BUCKET"
+binding = "LOGS_BUCKET"
 bucket_name = "hassio-proxy-artifacts"
+
+[[durable_objects.bindings]]
+name = "WEBSOCKET_SERVER"
+class_name = "HomeAssistantWebSocket"


### PR DESCRIPTION
## Summary
- add AI and durable object bindings in wrangler config
- store Home Assistant logs in R2 and analyze errors with Workers AI
- scaffold durable object to maintain websocket sessions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6fba656c8832eaa79c3695b9d85fc