### PR TITLE
feat: add Home Assistant websocket client

### DIFF
--- a/src/durable-objects/homeAssistant.ts
+++ b/src/durable-objects/homeAssistant.ts
@@ -43,7 +43,9 @@ export class HomeAssistantWebSocket implements DurableObject {
   private async ensureHaSocket(instanceId: string) {
     if (this.haSocket && this.haSocket.readyState <= 1) return;
 
-    const config = await getInstanceConfig(this.env, instanceId);
+    const config = this.env.HASSIO_ENDPOINT_URI && this.env.HASSIO_TOKEN
+      ? { baseUrl: this.env.HASSIO_ENDPOINT_URI, token: this.env.HASSIO_TOKEN }
+      : await getInstanceConfig(this.env, instanceId);
     if (!config) return;
 
     const wsUrl = config.baseUrl.replace(/^http/, 'ws') + '/api/websocket';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,7 +35,9 @@ const bindings = {
     get() {
       return { fetch: () => new Response('not implemented', { status: 501 }) } as any;
     }
-  } as any
+  } as any,
+  HASSIO_ENDPOINT_URI: 'https://ha',
+  HASSIO_TOKEN: 'token'
 };
 const ctx = { waitUntil() {} } as any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export interface Env {
   LOGS_BUCKET: R2Bucket;
   AI: Ai;
   WEBSOCKET_SERVER: DurableObjectNamespace<HomeAssistantWebSocket>;
+  HASSIO_ENDPOINT_URI: string;
+  HASSIO_TOKEN: string;
 }
 
 const app = new Hono<{ Bindings: Env }>();

--- a/src/lib/homeAssistantWs.ts
+++ b/src/lib/homeAssistantWs.ts
@@ -1,0 +1,143 @@
+/**
+ * Home Assistant WebSocket client for Cloudflare Workers.
+ *
+ * This client wraps the Home Assistant WebSocket API allowing any supported
+ * command to be issued and responses awaited. It authenticates using
+ * `env.HASSIO_TOKEN` and connects to the instance configured by
+ * `env.HASSIO_ENDPOINT_URI`.
+ */
+
+import type { Env } from '../index';
+
+interface PendingRequest {
+  resolve: (value: any) => void;
+  reject: (reason?: any) => void;
+}
+
+/**
+ * `HaWebSocketClient` manages a persistent authenticated WebSocket connection
+ * to a Home Assistant instance. Messages are automatically given unique IDs and
+ * the corresponding responses are routed back to the caller.
+ */
+export class HaWebSocketClient {
+  private socket?: WebSocket;
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private authPromise?: Promise<void>;
+
+  constructor(private readonly url: string, private readonly token: string) {}
+
+  /**
+   * Connects to the Home Assistant WebSocket API if not already connected.
+   * The returned promise resolves once authentication succeeds.
+   */
+  private async connect(): Promise<void> {
+    if (this.socket && this.socket.readyState <= 1) {
+      return this.authPromise;
+    }
+
+    const wsUrl = this.url.replace(/^http/, 'ws') + '/api/websocket';
+    this.socket = new WebSocket(wsUrl);
+
+    this.authPromise = new Promise((resolve, reject) => {
+      const sock = this.socket!;
+
+      sock.addEventListener('open', () => {
+        sock.send(JSON.stringify({ type: 'auth', access_token: this.token }));
+      });
+
+      sock.addEventListener('message', (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.type === 'auth_ok') {
+            resolve();
+            return;
+          }
+          if (typeof msg.id === 'number' && this.pending.has(msg.id)) {
+            this.pending.get(msg.id)!.resolve(msg);
+            this.pending.delete(msg.id);
+          }
+        } catch (err) {
+          // ignore malformed messages
+        }
+      });
+
+      const fail = (err: any) => {
+        reject(err);
+        this.socket = undefined;
+        this.authPromise = undefined;
+      };
+
+      sock.addEventListener('close', () => fail(new Error('socket closed')));
+      sock.addEventListener('error', (ev) => fail(ev));
+    });
+
+    return this.authPromise;
+  }
+
+  /**
+   * Sends an arbitrary command over the WebSocket connection.
+   *
+   * @param command Partial Home Assistant command object. The `id` field will
+   *   be added automatically.
+   * @returns The parsed response message from Home Assistant.
+   */
+  async send<T = any>(command: Record<string, any>): Promise<T> {
+    await this.connect();
+    const id = this.nextId++;
+    const payload = { ...command, id };
+
+    return new Promise<T>((resolve, reject) => {
+      if (!this.socket) {
+        reject(new Error('socket not connected'));
+        return;
+      }
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.socket.send(JSON.stringify(payload));
+      } catch (err) {
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  /** Convenience wrapper for `call_service` commands. */
+  callService(domain: string, service: string, serviceData?: Record<string, any>) {
+    return this.send({
+      type: 'call_service',
+      domain,
+      service,
+      service_data: serviceData,
+    });
+  }
+
+  /** Convenience wrapper for `get_states` command. */
+  getStates() {
+    return this.send({ type: 'get_states' });
+  }
+
+  /** Convenience wrapper for `get_services` command. */
+  getServices() {
+    return this.send({ type: 'get_services' });
+  }
+
+  /** Convenience wrapper for `get_config` command. */
+  getConfig() {
+    return this.send({ type: 'get_config' });
+  }
+}
+
+let client: HaWebSocketClient | undefined;
+
+/**
+ * Returns a singleton `HaWebSocketClient` instance configured from environment
+ * bindings. Subsequent calls reuse the existing connection.
+ */
+export function getHaClient(env: Env): HaWebSocketClient {
+  if (!client) {
+    client = new HaWebSocketClient(env.HASSIO_ENDPOINT_URI, env.HASSIO_TOKEN);
+  }
+  return client;
+}
+

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { ok } from '../lib/response';
 import type { Env } from '../index';
 import { haFetch } from '../lib/homeAssistant';
+import { getHaClient } from '../lib/homeAssistantWs';
 
 
 export const v1 = new Hono<{ Bindings: Env }>();
@@ -99,4 +100,11 @@ v1.post('/ha/:instanceId/services/:domain/:service', async (c) => {
   });
   const data = await res.json();
   return c.json(ok('service called', data));
+});
+
+// Generic Home Assistant WebSocket command endpoint using worker-configured instance
+v1.post('/ha/ws', async (c) => {
+  const command = await c.req.json();
+  const data = await getHaClient(c.env).send(command);
+  return c.json(ok('ws response', data));
 });


### PR DESCRIPTION
## Summary
- add reusable Home Assistant WebSocket client using env secrets
- expose generic HA WebSocket command endpoint and env bindings
- extend Durable Object to use worker-configured Home Assistant instance

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b75d00bc832e8b4d6c070f7d5cf5