### PR TITLE
fix: update zod and build config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "hassio-proxy-worker",
+  "name": "hassio-proxy",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hassio-proxy-worker",
+      "name": "hassio-proxy",
       "version": "0.1.0",
       "dependencies": {
         "ai": "^5.0.22",
         "hono": "^4.4.7",
         "workers-ai-provider": "^0.7.5",
-        "zod": "^3.25.0"
+        "zod": "3.25.76"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240512.0",
@@ -19,22 +19,6 @@
         "typescript": "^5.5.4",
         "vitest": "^1.6.0",
         "wrangler": "^3.60.0"
-      }
-    },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.11.tgz",
-      "integrity": "sha512-ErwWS3sPOuWy42eE3AVxlKkTa1XjjKBEtNCOylVKMO5KNyz5qie8QVlLYbULOG56dtxX4zTKX3rQNJudplhcmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -47,24 +31,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.5.tgz",
-      "integrity": "sha512-HliwB/yzufw3iwczbFVE2Fiwf1XqROB/I6ng8EKUsPM5+2wnIa8f4VbljZcDx+grhFrPV+PnRZH7zBqi8WZM7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.3",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1487,6 +1453,40 @@
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.5",
         "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/gateway": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.11.tgz",
+      "integrity": "sha512-ErwWS3sPOuWy42eE3AVxlKkTa1XjjKBEtNCOylVKMO5KNyz5qie8QVlLYbULOG56dtxX4zTKX3rQNJudplhcmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.5.tgz",
+      "integrity": "sha512-HliwB/yzufw3iwczbFVE2Fiwf1XqROB/I6ng8EKUsPM5+2wnIa8f4VbljZcDx+grhFrPV+PnRZH7zBqi8WZM7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.3",
+        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ai": "^5.0.22",
     "hono": "^4.4.7",
     "workers-ai-provider": "^0.7.5",
-    "zod": "^3.25.0"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240512.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       ai:
         specifier: ^5.0.22
-        version: 5.0.22(zod@3.25.0)
+        version: 5.0.22(zod@3.25.76)
       hono:
         specifier: ^4.4.7
         version: 4.9.0
       workers-ai-provider:
         specifier: ^0.7.5
-        version: 0.7.5(zod@3.25.0)
+        version: 0.7.5(zod@3.25.76)
       zod:
-        specifier: ^3.25.0
-        version: 3.25.0
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240512.0
@@ -1158,31 +1158,31 @@ packages:
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
-  zod@3.25.0:
-    resolution: {integrity: sha512-ficnZKUW0mlNivqeJkosTEkGbJ6NKCtSaOHGx5aXbtfeWMdRyzXLbAIn19my4C/KB7WPY/p9vlGPt+qpOp6c4Q==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@1.0.11(zod@3.25.0)':
+  '@ai-sdk/gateway@1.0.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.0)
-      zod: 3.25.0
+      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.0)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.25.0
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.5(zod@3.25.0)':
+  '@ai-sdk/provider-utils@3.0.5(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.5
-      zod: 3.25.0
-      zod-to-json-schema: 3.24.6(zod@3.25.0)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -1574,13 +1574,13 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@5.0.22(zod@3.25.0):
+  ai@5.0.22(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 1.0.11(zod@3.25.0)
+      '@ai-sdk/gateway': 1.0.11(zod@3.25.76)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.0)
+      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.0
+      zod: 3.25.76
 
   ansi-styles@5.2.0: {}
 
@@ -2081,10 +2081,10 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250718.0
       '@cloudflare/workerd-windows-64': 1.20250718.0
 
-  workers-ai-provider@0.7.5(zod@3.25.0):
+  workers-ai-provider@0.7.5(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.0)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 
@@ -2118,10 +2118,10 @@ snapshots:
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  zod-to-json-schema@3.24.6(zod@3.25.0):
+  zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
-      zod: 3.25.0
+      zod: 3.25.76
 
   zod@3.22.3: {}
 
-  zod@3.25.0: {}
+  zod@3.25.76: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { v1 } from './routes/v1';
-import type { HomeAssistantWebSocket } from './durable-objects/homeAssistant';
+export { HomeAssistantWebSocket } from './durable-objects/homeAssistant';
 
 export interface Env {
   D1_DB: D1Database;
@@ -9,7 +9,7 @@ export interface Env {
   CACHE_KV: KVNamespace;
   LOGS_BUCKET: R2Bucket;
   AI: Ai;
-  WEBSOCKET_SERVER: DurableObjectNamespace<HomeAssistantWebSocket>;
+  WEBSOCKET_SERVER: DurableObjectNamespace;
   HASSIO_ENDPOINT_URI: string;
   HASSIO_TOKEN: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "lib": ["ES2022", "DOM"],
-    "types": ["@cloudflare/workers-types"]
+    "types": ["@cloudflare/workers-types", "node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- upgrade to zod 3.25.76 to expose `zod/v4`
- exclude tests from ts build and include node types
- export `HomeAssistantWebSocket` for wrangler and simplify durable object typing

## Testing
- `pnpm test`
- `pnpm build`
- `npx wrangler deploy --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68abe38a9840832ea56dd908f1ca27b5