### PR TITLE
fix: resolve zod path build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "hassio-proxy-worker",
+  "name": "hassio-proxy",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hassio-proxy-worker",
+      "name": "hassio-proxy",
       "version": "0.1.0",
       "dependencies": {
         "ai": "^5.0.22",
         "hono": "^4.4.7",
         "workers-ai-provider": "^0.7.5",
-        "zod": "^3.25.0"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240512.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ai": "^5.0.22",
     "hono": "^4.4.7",
     "workers-ai-provider": "^0.7.5",
-    "zod": "^3.25.0"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240512.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       ai:
         specifier: ^5.0.22
-        version: 5.0.22(zod@3.25.0)
+        version: 5.0.22(zod@3.25.76)
       hono:
         specifier: ^4.4.7
         version: 4.9.0
       workers-ai-provider:
         specifier: ^0.7.5
-        version: 0.7.5(zod@3.25.0)
+        version: 0.7.5(zod@3.25.76)
       zod:
-        specifier: ^3.25.0
-        version: 3.25.0
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240512.0
@@ -1155,34 +1155,31 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.22.3:
-    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
-
-  zod@3.25.0:
-    resolution: {integrity: sha512-ficnZKUW0mlNivqeJkosTEkGbJ6NKCtSaOHGx5aXbtfeWMdRyzXLbAIn19my4C/KB7WPY/p9vlGPt+qpOp6c4Q==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@1.0.11(zod@3.25.0)':
+  '@ai-sdk/gateway@1.0.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.0)
-      zod: 3.25.0
+      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.0)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.25.0
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.5(zod@3.25.0)':
+  '@ai-sdk/provider-utils@3.0.5(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.5
-      zod: 3.25.0
-      zod-to-json-schema: 3.24.6(zod@3.25.0)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -1574,13 +1571,13 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@5.0.22(zod@3.25.0):
+  ai@5.0.22(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 1.0.11(zod@3.25.0)
+      '@ai-sdk/gateway': 1.0.11(zod@3.25.76)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.0)
+      '@ai-sdk/provider-utils': 3.0.5(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.0
+      zod: 3.25.76
 
   ansi-styles@5.2.0: {}
 
@@ -2081,10 +2078,10 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250718.0
       '@cloudflare/workerd-windows-64': 1.20250718.0
 
-  workers-ai-provider@0.7.5(zod@3.25.0):
+  workers-ai-provider@0.7.5(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.0)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 
@@ -2118,10 +2115,8 @@ snapshots:
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  zod-to-json-schema@3.24.6(zod@3.25.0):
+  zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
-      zod: 3.25.0
+      zod: 3.25.76
 
-  zod@3.22.3: {}
-
-  zod@3.25.0: {}
+  zod@3.25.76: {}

--- a/src/durable-objects/homeAssistant.ts
+++ b/src/durable-objects/homeAssistant.ts
@@ -1,4 +1,4 @@
-import type { Env } from '../index';
+import type { Env } from '../types';
 import { getInstanceConfig } from '../lib/homeAssistant';
 
 export class HomeAssistantWebSocket implements DurableObject {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,7 +5,7 @@ vi.mock('ai', () => ({
 }));
 
 import app from './index';
-import type { Env } from './index';
+import type { Env } from './types';
 
 // Simple mocks for bindings with minimal type fixes
 const bindings: Env = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,7 @@
 import { Hono } from 'hono';
 import { v1 } from './routes/v1';
-import type { HomeAssistantWebSocket } from './durable-objects/homeAssistant';
-
-export interface Env {
-  D1_DB: D1Database;
-  CONFIG_KV: KVNamespace;
-  SESSIONS_KV: KVNamespace;
-  CACHE_KV: KVNamespace;
-  LOGS_BUCKET: R2Bucket;
-  AI: Ai;
-  WEBSOCKET_SERVER: DurableObjectNamespace<HomeAssistantWebSocket>;
-  HASSIO_ENDPOINT_URI: string;
-  HASSIO_TOKEN: string;
-}
+import type { Env } from './types';
+export type { Env } from './types';
 
 const app = new Hono<{ Bindings: Env }>();
 

--- a/src/lib/homeAssistant.ts
+++ b/src/lib/homeAssistant.ts
@@ -1,4 +1,4 @@
-import type { Env } from '../index';
+import type { Env } from '../types';
 
 export interface InstanceConfig {
   baseUrl: string;

--- a/src/lib/homeAssistantWs.ts
+++ b/src/lib/homeAssistantWs.ts
@@ -7,7 +7,7 @@
  * `env.HASSIO_ENDPOINT_URI`.
  */
 
-import type { Env } from '../index';
+import type { Env } from '../types';
 
 interface PendingRequest {
   resolve: (value: any) => void;

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { ok } from '../lib/response';
-import type { Env } from '../index';
+import type { Env } from '../types';
 import { haFetch } from '../lib/homeAssistant';
 import { getHaClient } from '../lib/homeAssistantWs';
 import { createWorkersAI } from 'workers-ai-provider';

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface Env {
   CACHE_KV: KVNamespace;
   LOGS_BUCKET: R2Bucket;
   AI: Ai;
-  WEBSOCKET_SERVER: DurableObjectNamespace<HomeAssistantWebSocket>;
+  WEBSOCKET_SERVER: DurableObjectNamespace;
   HASSIO_ENDPOINT_URI: string;
   HASSIO_TOKEN: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+import type { HomeAssistantWebSocket } from './durable-objects/homeAssistant';
+
+export interface Env {
+  D1_DB: D1Database;
+  CONFIG_KV: KVNamespace;
+  SESSIONS_KV: KVNamespace;
+  CACHE_KV: KVNamespace;
+  LOGS_BUCKET: R2Bucket;
+  AI: Ai;
+  WEBSOCKET_SERVER: DurableObjectNamespace<HomeAssistantWebSocket>;
+  HASSIO_ENDPOINT_URI: string;
+  HASSIO_TOKEN: string;
+}
+


### PR DESCRIPTION
## Summary
- upgrade zod to 3.25.76 to provide v4 entrypoint
- refresh lockfiles
- centralize Env type in src/types and update imports

## Testing
- `pnpm test`
- `pnpm build` *(fails: 'data' is of type 'unknown'; HomeAssistantWebSocket missing Durable Object brand)*
- `npx wrangler deploy --dry-run` *(fails: Could not resolve "zod/v4")*


------
https://chatgpt.com/codex/tasks/task_e_68abeacbe810832e8f5898079987e771