### PR TITLE
feat: add verbose logging

### DIFF
--- a/src/durable-objects/homeAssistant.ts
+++ b/src/durable-objects/homeAssistant.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../index';
 import { getInstanceConfig } from '../lib/homeAssistant';
+import { logger } from '../lib/logger';
 
 export class HomeAssistantWebSocket implements DurableObject {
   private readonly state: DurableObjectState;
@@ -14,11 +15,13 @@ export class HomeAssistantWebSocket implements DurableObject {
 
   async fetch(request: Request) {
     if (request.headers.get('Upgrade') !== 'websocket') {
+      logger.warn('Non-websocket request to HomeAssistantWebSocket');
       return new Response('Expected websocket', { status: 400 });
     }
 
     const url = new URL(request.url);
     const instanceId = url.pathname.split('/').pop() || 'default';
+    logger.debug('HomeAssistantWebSocket fetch for', instanceId);
     await this.ensureHaSocket(instanceId);
 
     const pair = new WebSocketPair();
@@ -47,10 +50,14 @@ export class HomeAssistantWebSocket implements DurableObject {
     const config = this.env.HASSIO_ENDPOINT_URI && this.env.HASSIO_TOKEN
       ? { baseUrl: this.env.HASSIO_ENDPOINT_URI, token: this.env.HASSIO_TOKEN }
       : await getInstanceConfig(this.env, instanceId);
-    if (!config) return;
+    if (!config) {
+      logger.warn('No HA config found for instance', instanceId);
+      return;
+    }
 
     const wsUrl = config.baseUrl.replace(/^http/, 'ws') + '/api/websocket';
     this.haSocket = new WebSocket(wsUrl);
+    logger.debug('Opening HA socket', wsUrl);
     this.haSocket.addEventListener('open', () => {
       this.haSocket!.send(
         JSON.stringify({ type: 'auth', access_token: config.token })
@@ -64,9 +71,11 @@ export class HomeAssistantWebSocket implements DurableObject {
       }
     });
     this.haSocket.addEventListener('close', () => {
+      logger.warn('HA socket closed');
       this.haSocket = undefined;
     });
     this.haSocket.addEventListener('error', () => {
+      logger.error('HA socket error');
       this.haSocket = undefined;
     });
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,60 @@
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+}
+
+let currentLevel: LogLevel = LogLevel.DEBUG;
+
+function shouldLog(level: LogLevel) {
+  return level >= currentLevel;
+}
+
+function formatLevel(level: LogLevel): string {
+  switch (level) {
+    case LogLevel.DEBUG:
+      return 'DEBUG';
+    case LogLevel.INFO:
+      return 'INFO';
+    case LogLevel.WARN:
+      return 'WARN';
+    case LogLevel.ERROR:
+      return 'ERROR';
+    default:
+      return 'LOG';
+  }
+}
+
+function log(level: LogLevel, ...args: unknown[]) {
+  if (!shouldLog(level)) {
+    return;
+  }
+  const prefix = `[${formatLevel(level)}]`;
+  switch (level) {
+    case LogLevel.DEBUG:
+      console.debug(prefix, ...args);
+      break;
+    case LogLevel.INFO:
+      console.info(prefix, ...args);
+      break;
+    case LogLevel.WARN:
+      console.warn(prefix, ...args);
+      break;
+    case LogLevel.ERROR:
+      console.error(prefix, ...args);
+      break;
+    default:
+      console.log(prefix, ...args);
+  }
+}
+
+export const logger = {
+  setLevel(level: LogLevel) {
+    currentLevel = level;
+  },
+  debug: (...args: unknown[]) => log(LogLevel.DEBUG, ...args),
+  info: (...args: unknown[]) => log(LogLevel.INFO, ...args),
+  warn: (...args: unknown[]) => log(LogLevel.WARN, ...args),
+  error: (...args: unknown[]) => log(LogLevel.ERROR, ...args),
+};


### PR DESCRIPTION
## Summary
- implement basic logger with adjustable levels
- add request and diagnostic logging across routes and Home Assistant helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac0782f2d8832ebca60dc109802545