### PR TITLE
Add functional voice agent using Cloudflare STT/TTS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,14 @@
       </div>
     </section>
 
+    <!-- Voice Agent Section -->
+    <section class="bg-gray-800 rounded-lg p-6">
+      <h2 class="text-xl font-semibold mb-4">Voice Agent</h2>
+      <p>
+        <a href="/voice-agent.html" class="text-blue-400 underline">Open real-time voice agent</a>
+      </p>
+    </section>
+
     <!-- Test Results Section -->
     <section class="bg-gray-800 rounded-lg p-6">
       <h2 class="text-xl font-semibold mb-4">Test Results</h2>

--- a/public/voice-agent.html
+++ b/public/voice-agent.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Voice Agent</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-gray-100 font-sans p-4">
+  <h1 class="text-2xl font-bold mb-4">Real-time Voice Agent</h1>
+  <p class="mb-4">Press the button and speak a question. Release to send.</p>
+  <button id="record" class="px-3 py-2 bg-blue-600 hover:bg-blue-500 rounded">Start Recording</button>
+  <div id="transcript" class="mt-4 whitespace-pre-wrap"></div>
+  <script>
+    let mediaRecorder;
+    let chunks = [];
+    const button = document.getElementById('record');
+    const transcriptEl = document.getElementById('transcript');
+    let recording = false;
+
+    async function startRecording() {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRecorder = new MediaRecorder(stream);
+      chunks = [];
+      mediaRecorder.ondataavailable = e => chunks.push(e.data);
+      mediaRecorder.start();
+      recording = true;
+      button.textContent = 'Stop Recording';
+    }
+
+    async function stopRecording() {
+      return new Promise(resolve => {
+        mediaRecorder.onstop = resolve;
+        mediaRecorder.stop();
+      });
+    }
+
+    async function sendAudio() {
+      const blob = new Blob(chunks, { type: 'audio/webm' });
+      const arrayBuffer = await blob.arrayBuffer();
+      const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+      const res = await fetch('/v1/ai/voice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audio: base64 })
+      });
+      const data = await res.json();
+      transcriptEl.textContent = `You said: ${data.data.transcript}\nAgent: ${data.data.reply}`;
+      if (data.data.audio) {
+        const audio = new Audio('data:audio/wav;base64,' + data.data.audio);
+        audio.play();
+      }
+    }
+
+    button.addEventListener('click', async () => {
+      if (!recording) {
+        await startRecording();
+      } else {
+        await stopRecording();
+        recording = false;
+        button.textContent = 'Start Recording';
+        await sendAudio();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/voice-agent.html
+++ b/public/voice-agent.html
@@ -19,13 +19,18 @@
     let recording = false;
 
     async function startRecording() {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      mediaRecorder = new MediaRecorder(stream);
-      chunks = [];
-      mediaRecorder.ondataavailable = e => chunks.push(e.data);
-      mediaRecorder.start();
-      recording = true;
-      button.textContent = 'Stop Recording';
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        mediaRecorder = new MediaRecorder(stream);
+        chunks = [];
+        mediaRecorder.ondataavailable = e => chunks.push(e.data);
+        mediaRecorder.start();
+        recording = true;
+        button.textContent = 'Stop Recording';
+      } catch (err) {
+        console.error('Error starting recording:', err);
+        transcriptEl.textContent = 'Could not start recording. Please grant microphone permission.';
+      }
     }
 
     async function stopRecording() {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,12 @@ vi.mock('ai', () => ({
   generateText: async () => ({ text: 'mocked summary' })
 }));
 
+vi.mock('./lib/homeAssistantWs', () => ({
+  getHaClient: () => ({
+    getStates: async () => []
+  })
+}));
+
 import app from './index';
 import type { Env } from './index';
 
@@ -33,7 +39,13 @@ const bindings: Env = {
   SESSIONS_KV: { async get() {}, async put() {}, async delete() {} } as any,
   CACHE_KV: { async get() {}, async put() {}, async delete() {} } as any,
   LOGS_BUCKET: { async put() {} } as any,
-  AI: { async run() { return { response: 'diag' }; } } as any,
+  AI: {
+    async run(model: string) {
+      if (model.includes('whisper')) return { text: 'hello' } as any;
+      if (model.includes('gpt-4o-mini-tts')) return { audio_base64: 'fakeaudio' } as any;
+      return { response: 'diag' } as any;
+    }
+  } as any,
   WEBSOCKET_SERVER: {
     idFromName() {
       return {} as any;
@@ -100,6 +112,19 @@ describe('Alexa REST API scaffold', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.data).toEqual({ text: 'mocked summary' });
+  });
+
+  it('handles voice interaction', async () => {
+    const res = await app.request(
+      '/v1/ai/voice',
+      { method: 'POST', body: JSON.stringify({ audio: 'abc' }) },
+      bindings,
+      ctx
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.data.transcript).toBe('hello');
+    expect(data.data.audio).toBe('fakeaudio');
   });
 
   it('proxies Home Assistant state', async () => {


### PR DESCRIPTION
## Summary
- expose a real-time voice agent link on the dashboard
- implement voice agent page with audio recording and playback via Cloudflare STT/TTS
- add backend route `/v1/ai/voice` and tests for voice interactions

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4abf4b06c832eb8723dd9f75c3622