### PR TITLE
Decode base64 audio before Cloudflare whisper call

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,9 +115,10 @@ describe('Alexa REST API scaffold', () => {
   });
 
   it('handles voice interaction', async () => {
+    const audioBase64 = Buffer.from('abc').toString('base64');
     const res = await app.request(
       '/v1/ai/voice',
-      { method: 'POST', body: JSON.stringify({ audio: 'abc' }) },
+      { method: 'POST', body: JSON.stringify({ audio: audioBase64 }) },
       bindings,
       ctx
     );


### PR DESCRIPTION
## Summary
- decode incoming base64 audio into Uint8Array for Cloudflare Whisper
- tighten STT/TTS response types
- update voice route test to send base64 audio

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e55bf788832e889c907e4b9bbe4f