### PR TITLE
Batch entity inserts via db.batch

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,15 +9,21 @@ import worker from "./index";
 
 // Simple mocks for bindings with minimal type fixes
 const bindings: WorkerEnv = {
-	D1_DB: {
-		prepare() {
-			return {
-				bind() {
-					return { async run() {} };
-				},
-			};
-		},
-	} as any,
+        D1_DB: {
+                prepare() {
+                        return {
+                                bind() {
+                                        return { async run() {} };
+                                },
+                        };
+                },
+                async batch(statements: any[]) {
+                        for (const stmt of statements) {
+                                await stmt.run();
+                        }
+                        return statements.map(() => ({ success: true }));
+                },
+        } as any,
 	CONFIG_KV: {
 		store: {} as Record<string, string>,
 		async get(key: string) {


### PR DESCRIPTION
## Summary
- batch entity insert statements in `syncEntitiesFromHA`
- mock `db.batch` in tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b637d41914832e849ecc6465a087a9